### PR TITLE
feat: CommitLoggerを複数組み合わせられるCompositeCommitLoggerを追加

### DIFF
--- a/src/main/java/nablarch/core/log/app/CompositeCommitLogger.java
+++ b/src/main/java/nablarch/core/log/app/CompositeCommitLogger.java
@@ -1,0 +1,41 @@
+package nablarch.core.log.app;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * 複数の{@link CommitLogger}を組み合わせたロガークラス。
+ * @author Tanaka Tomoyuki
+ */
+public class CompositeCommitLogger implements CommitLogger {
+    private List<? extends CommitLogger> commitLoggerList = Collections.emptyList();
+
+    @Override
+    public void initialize() {
+        for (CommitLogger commitLogger : commitLoggerList) {
+            commitLogger.initialize();
+        }
+    }
+
+    @Override
+    public void increment(long count) {
+        for (CommitLogger commitLogger : commitLoggerList) {
+            commitLogger.increment(count);
+        }
+    }
+
+    @Override
+    public void terminate() {
+        for (CommitLogger commitLogger : commitLoggerList) {
+            commitLogger.terminate();
+        }
+    }
+
+    /**
+     * {@link CommitLogger}のリストを設定する。
+     * @param commitLoggerList {@link CommitLogger}のリスト
+     */
+    public void setCommitLoggerList(List<? extends CommitLogger> commitLoggerList) {
+        this.commitLoggerList = commitLoggerList;
+    }
+}

--- a/src/test/java/nablarch/core/log/app/CompositeCommitLoggerTest.java
+++ b/src/test/java/nablarch/core/log/app/CompositeCommitLoggerTest.java
@@ -1,0 +1,73 @@
+package nablarch.core.log.app;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * {@link CompositeCommitLogger}の単体テスト。
+ * @author Tanaka Tomoyuki
+ */
+public class CompositeCommitLoggerTest {
+    private CompositeCommitLogger sut = new CompositeCommitLogger();
+    private MockCommitLogger logger1 = new MockCommitLogger();
+    private MockCommitLogger logger2 = new MockCommitLogger();
+    private MockCommitLogger logger3 = new MockCommitLogger();
+
+    @Before
+    public void setup() {
+        sut.setCommitLoggerList(Arrays.asList(logger1, logger2, logger3));
+    }
+
+    @Test
+    public void testInitialize() {
+        sut.initialize();
+
+        assertThat(logger1.initialized, is(true));
+        assertThat(logger2.initialized, is(true));
+        assertThat(logger3.initialized, is(true));
+    }
+
+    @Test
+    public void testIncrement() {
+        sut.increment(99L);
+
+        assertThat(logger1.count, is(99L));
+        assertThat(logger2.count, is(99L));
+        assertThat(logger3.count, is(99L));
+    }
+
+    @Test
+    public void testTerminate() {
+        sut.terminate();
+
+        assertThat(logger1.terminated, is(true));
+        assertThat(logger2.terminated, is(true));
+        assertThat(logger3.terminated, is(true));
+    }
+
+    private static class MockCommitLogger implements CommitLogger {
+        private boolean initialized;
+        private long count;
+        private boolean terminated;
+
+        @Override
+        public void initialize() {
+            initialized = true;
+        }
+
+        @Override
+        public void increment(long count) {
+            this.count = count;
+        }
+
+        @Override
+        public void terminate() {
+            terminated = true;
+        }
+    }
+}


### PR DESCRIPTION
https://github.com/nablarch/nablarch-micrometer-adaptor/pull/7

上記修正の、バッチのトランザクションごとの処理時間を計測する `CommitLogger` の追加に関連する修正です。

現状利用されている `BasicCommitLogger` と下記のように併用できるように、複数の `CommitLogger` をまとめられるクラスを追加しました。

```xml
<component name="commitLogger" class="...CompositeCommitLogger">
  <property name="commitLoggerList">
    <list>
      <component class="...BasicCommitLogger">...</component>
      <component class="...BatchTransactionTimeMetricsLogger">...</component>
    </list>
  </property>
</component>
```