### PR TITLE
feat: 出力されたログを任意のリスナーに公開するLogPublisherを追加

### DIFF
--- a/src/main/java/nablarch/core/log/basic/LogListener.java
+++ b/src/main/java/nablarch/core/log/basic/LogListener.java
@@ -1,0 +1,14 @@
+package nablarch.core.log.basic;
+
+/**
+ * {@link LogPublisher}によって公開された{@link LogContext}を受け取るインタフェース。
+ * @author Tanaka Tomoyuki
+ */
+public interface LogListener {
+
+    /**
+     * 公開された{@link LogContext}を受け取る。
+     * @param context {@link LogContext}
+     */
+    void onWritten(LogContext context);
+}

--- a/src/main/java/nablarch/core/log/basic/LogPublisher.java
+++ b/src/main/java/nablarch/core/log/basic/LogPublisher.java
@@ -11,6 +11,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
  * @author Tanaka Tomoyuki
  */
 public class LogPublisher implements LogWriter {
+    /** ログの公開先となる{@link LogListener}のリスト。 */
     private static final CopyOnWriteArrayList<LogListener> LISTENERS = new CopyOnWriteArrayList<LogListener>();
 
     /**

--- a/src/main/java/nablarch/core/log/basic/LogPublisher.java
+++ b/src/main/java/nablarch/core/log/basic/LogPublisher.java
@@ -1,0 +1,55 @@
+package nablarch.core.log.basic;
+
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * 書き出されたログを、登録された{@link LogListener}に公開する{@link LogWriter}の実装クラス。
+ * <p>
+ * {@link LogWriter}のインスタンスは外部から取得できないため、
+ * 公開対象の{@link LogListener}は{@code static}変数で保持している。
+ * </p>
+ * @author Tanaka Tomoyuki
+ */
+public class LogPublisher implements LogWriter {
+    private static final CopyOnWriteArrayList<LogListener> LISTENERS = new CopyOnWriteArrayList<LogListener>();
+
+    /**
+     * 公開対象の{@link LogListener}を追加する。
+     * @param listener {@link LogListener}
+     */
+    public static void addListener(LogListener listener) {
+        LISTENERS.add(listener);
+    }
+
+    /**
+     * 公開対象から指定した{@link LogListener}を削除する。
+     * @param listener {@link LogListener}
+     */
+    public static void removeListener(LogListener listener) {
+        LISTENERS.remove(listener);
+    }
+
+    /**
+     * 登録されているすべての{@link LogListener}を削除する。
+     */
+    public static void removeAllListeners() {
+        LISTENERS.clear();
+    }
+
+    @Override
+    public void write(LogContext context) {
+        for (LogListener listener : LISTENERS) {
+            listener.onWritten(context);
+        }
+    }
+
+    @Override
+    public void initialize(ObjectSettings settings) {
+        // noop
+    }
+
+    @Override
+    public void terminate() {
+        // noop
+    }
+}

--- a/src/test/java/nablarch/core/log/basic/LogPublisherTest.java
+++ b/src/test/java/nablarch/core/log/basic/LogPublisherTest.java
@@ -1,0 +1,73 @@
+package nablarch.core.log.basic;
+
+import org.junit.After;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * {@link LogPublisher}の単体テスト。
+ * @author Tanaka Tomoyuki
+ */
+public class LogPublisherTest {
+
+    @Test
+    public void testWrite() {
+        TestLogListener listener1 = new TestLogListener();
+        TestLogListener listener2 = new TestLogListener();
+        LogPublisher.addListener(listener1);
+        LogPublisher.addListener(listener2);
+
+        LogPublisher sut = new LogPublisher();
+        LogContext logContext = new LogContext("loggerName", LogLevel.INFO, "message", null);
+        sut.write(logContext);
+
+        assertThat(listener1.logContext, is(sameInstance(logContext)));
+        assertThat(listener2.logContext, is(sameInstance(logContext)));
+    }
+
+    @Test
+    public void testRemoveListener() {
+        TestLogListener listener1 = new TestLogListener();
+        TestLogListener listener2 = new TestLogListener();
+        LogPublisher.addListener(listener1);
+        LogPublisher.addListener(listener2);
+
+        LogPublisher.removeListener(listener1);
+
+        LogPublisher sut = new LogPublisher();
+        LogContext logContext = new LogContext("loggerName", LogLevel.INFO, "message", null);
+        sut.write(logContext);
+
+        assertThat(listener1.logContext, is(nullValue()));
+        assertThat(listener2.logContext, is(sameInstance(logContext)));
+    }
+
+    @Test
+    public void testNoopMethods() {
+        // 何もしないメソッドを実行しても何も起こらないことのテスト（テストの意味は薄いが、カバレッジを通すために実施している）
+        TestLogListener listener = new TestLogListener();
+        LogPublisher.addListener(listener);
+
+        LogPublisher sut = new LogPublisher();
+        sut.initialize(null);
+        sut.terminate();
+
+        assertThat(listener.logContext, is(nullValue()));
+    }
+
+    @After
+    public void tearDown() {
+        LogPublisher.removeAllListeners();
+    }
+
+    private static class TestLogListener implements LogListener {
+        private LogContext logContext;
+
+        @Override
+        public void onWritten(LogContext context) {
+            this.logContext = context;
+        }
+    }
+}


### PR DESCRIPTION
[nablarch-micrometer-adaptor のメトリクス拡充のPR](https://github.com/nablarch/nablarch-micrometer-adaptor/pull/8)の「1. ログレベルごとのログ出力回数をカウント」に関連する修正です。

`LogWriter` を実装し、 `write(LogContext)` で出力されたログの情報を任意のリスナー(`LogListener`)に連携する `LogPublisher` を追加しています。

`LogWriter` のインスタンスは外部から取得できない(`BasicLoggerFactory` の中に閉じている)ので、 `LogListener` の登録は `static` メソッドを介して行うようにしています。  
