### PR TITLE
test: jmockit -> mockito

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jmockit</groupId>
-      <artifactId>jmockit</artifactId>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/src/test/java/nablarch/core/log/basic/DateRotatePolicyTest.java
+++ b/src/test/java/nablarch/core/log/basic/DateRotatePolicyTest.java
@@ -1,7 +1,5 @@
 package nablarch.core.log.basic;
 
-import mockit.Mock;
-import mockit.MockUp;
 import nablarch.core.log.LogTestUtil;
 import nablarch.core.log.Logger;
 import nablarch.core.log.MockLogSettings;
@@ -26,6 +24,7 @@ import java.util.Map;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 /**
  * {@link DateRotatePolicy}のテスト。
@@ -262,14 +261,10 @@ public class DateRotatePolicyTest {
     /** パスにファイルが存在する場合、ファイルの更新時刻が取得できない場合に例外が発生すること */
     @Test
     public void testLastModifiedReturnsZero() {
-        new MockUp<File>() {
-            @Mock
-            public long lastModified() {
-                return 0;
-            }
-        };
-
-        newLogFile();
+        final File file = newLogFile();
+        
+        // 更新時刻に 0 を設定することで更新時刻を取得できない状態を再現する
+        assertTrue(file.setLastModified(0L));
 
         final DateRotatePolicy policy = new DateRotatePolicy();
 

--- a/src/test/java/nablarch/core/log/basic/FileLogWriterTest.java
+++ b/src/test/java/nablarch/core/log/basic/FileLogWriterTest.java
@@ -1,12 +1,12 @@
 package nablarch.core.log.basic;
 
-import mockit.*;
 import nablarch.core.log.LogTestSupport;
 import nablarch.core.log.LogTestUtil;
 import nablarch.core.log.MockLogSettings;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.function.ThrowingRunnable;
+import org.mockito.InOrder;
+import org.mockito.MockedConstruction;
 
 import java.io.File;
 import java.io.FileFilter;
@@ -16,7 +16,20 @@ import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 /**
  * {@link FileLogWriter}のテスト。
@@ -141,8 +154,7 @@ public class FileLogWriterTest extends LogTestSupport {
 
     /** initialize時に、RotatePolicyのインターフェースが正しく呼び出されていること */
     @Test
-    @Ignore("jacoco と jmockit が競合してエラーになるため")
-    public void testRotatePolicyWhenInitialize(@Capturing final RotatePolicy rotatePolicy) {
+    public void testRotatePolicyWhenInitialize() {
         LogTestUtil.cleanupLog("/testRotatePolicyWhenNoRotation-app.log");
 
         final String utf8 = "UTF-8";
@@ -155,28 +167,25 @@ public class FileLogWriterTest extends LogTestSupport {
 
         FileLogWriter writer = new FileLogWriter();
         final ObjectSettings objectSettings = new ObjectSettings(new MockLogSettings(settings), "appFile");
+        
+        try (final MockedConstruction<FileSizeRotatePolicy> mocked = mockConstruction(FileSizeRotatePolicy.class);) {
+            writer.initialize(objectSettings);
 
-        writer.initialize(objectSettings);
+            // initializeでは、initialize・onOpenFile・getSettings・onWriteが１回ずつ呼びされていることの確認
+            final RotatePolicy rotatePolicy = mocked.constructed().get(0);
 
-        // initializeでは、initialize・onOpenFile・getSettings・onWriteが１回ずつ呼びされていることの確認
-        new FullVerificationsInOrder() {
-            {
-                rotatePolicy.initialize(objectSettings);
-                times = 1;
-                rotatePolicy.onOpenFile(new File(path));
-                times = 1;
-                rotatePolicy.getSettings();
-                times = 1;
-                rotatePolicy.onWrite(anyString,Charset.forName(utf8));
-                times = 1;
-            }
-        };
+            final InOrder inOrder = inOrder(rotatePolicy);
+            inOrder.verify(rotatePolicy).initialize(objectSettings);
+            inOrder.verify(rotatePolicy).onOpenFile(new File(path));
+            inOrder.verify(rotatePolicy).getSettings();
+            inOrder.verify(rotatePolicy).onWrite(anyString(), eq(Charset.forName(utf8)));
+            verifyNoMoreInteractions(rotatePolicy);
+        }
     }
 
     /** ローテーションが不要な場合に、RotatePolicyのインターフェースが正しく呼び出されていること */
     @Test
-    @Ignore("jacoco と jmockit が競合してエラーになるため")
-    public void testRotatePolicyWhenNoRotation(@Capturing final RotatePolicy rotatePolicy) {
+    public void testRotatePolicyWhenNoRotation() {
         LogTestUtil.cleanupLog("/testRotatePolicyWhenNoRotation-app.log");
 
         final String utf8 = "UTF-8";
@@ -190,34 +199,30 @@ public class FileLogWriterTest extends LogTestSupport {
 
         FileLogWriter writer = new FileLogWriter();
         final ObjectSettings objectSettings = new ObjectSettings(new MockLogSettings(settings), "appFile");
+        
+        try (final MockedConstruction<FileSizeRotatePolicy> mocked = mockConstruction(FileSizeRotatePolicy.class)) {
+            writer.initialize(objectSettings);
+            
+            // initialize の中で RotatePolicy のモックと行われたインタラクションをリセットする
+            final RotatePolicy rotatePolicy = mocked.constructed().get(0);
+            reset(rotatePolicy);
+            when(rotatePolicy.needsRotate(message, Charset.forName(utf8))).thenReturn(false);
+            
+            writer.onWrite("HelloWorld");
 
-        writer.initialize(objectSettings);
-
-        new Expectations() {
-            {
-                rotatePolicy.needsRotate(message, Charset.forName(utf8));
-                result = false;
-            }
-        };
-
-        writer.onWrite("HelloWorld");
-
-        // onWriteでは、needsRotate・onWriteが１回ずつ呼びされていることの確認
-        // その他のメソッドは呼ばれていないことの確認
-        new FullVerificationsInOrder() {
-            {
-                rotatePolicy.needsRotate(message, Charset.forName(utf8));
-                times = 1;
-                rotatePolicy.onWrite(message, Charset.forName(utf8));
-                times = 1;
-            }
-        };
+            // onWriteでは、needsRotate・onWriteが１回ずつ呼びされていることの確認
+            // その他のメソッドは呼ばれていないことの確認
+            final InOrder inOrder = inOrder(rotatePolicy);
+            
+            inOrder.verify(rotatePolicy).needsRotate(message, Charset.forName(utf8));
+            inOrder.verify(rotatePolicy).onWrite(message, Charset.forName(utf8));
+            verifyNoMoreInteractions(rotatePolicy);
+        }
     }
 
     /** ローテーションが必要な場合に、RotatePolicyのインターフェースが正しく呼び出されていること */
     @Test
-    @Ignore("jacoco と jmockit が競合してエラーになるため")
-    public void testRotatePolicyWhenRotation(@Capturing final RotatePolicy rotatePolicy) {
+    public void testRotatePolicyWhenRotation() {
         LogTestUtil.cleanupLog("/testRotatePolicyWhenRotation-app.log");
 
         final String utf8 = "UTF-8";
@@ -234,42 +239,33 @@ public class FileLogWriterTest extends LogTestSupport {
         FileLogWriter writer = new FileLogWriter();
         final ObjectSettings objectSettings = new ObjectSettings(new MockLogSettings(settings), "appFile");
 
-        writer.initialize(objectSettings);
 
-        new Expectations() {
-            {
-                rotatePolicy.needsRotate(message, Charset.forName(utf8));
-                result = true;
+        try (final MockedConstruction<FileSizeRotatePolicy> mocked = mockConstruction(FileSizeRotatePolicy.class)) {
+            writer.initialize(objectSettings);
+            
+            // initialize の中で RotatePolicy のモックと行われたインタラクションをリセットする
+            final RotatePolicy rotatePolicy = mocked.constructed().get(0);
+            reset(rotatePolicy);
+            
+            when(rotatePolicy.needsRotate(message, Charset.forName(utf8))).thenReturn(true);
+            when(rotatePolicy.decideRotatedFilePath()).thenReturn(rotatedFilePath);
+            
+            writer.onWrite(message);
 
-                rotatePolicy.decideRotatedFilePath();
-                result = rotatedFilePath;
-            }
-        };
+            // onWriteではローテーションが必要な場合に、needsRotate・decideRotatedFilePath・onWrite
+            // rotate・onOpenFile・getSettings・onWriteの順で実装クラスが呼びされていることの確認
+            final InOrder inOrder = inOrder(rotatePolicy);
 
-        writer.onWrite(message);
-
-        // onWriteではローテーションが必要な場合に、needsRotate・decideRotatedFilePath・onWrite
-        // rotate・onOpenFile・getSettings・onWriteの順で実装クラスが呼びされていることの確認
-        new FullVerificationsInOrder() {
-            {
-                rotatePolicy.needsRotate(message, Charset.forName(utf8));
-                times = 1;
-
-                rotatePolicy.decideRotatedFilePath();
-                times = 1;
-                rotatePolicy.onWrite(anyString, Charset.forName(utf8));
-                times = 1;
-                rotatePolicy.rotate(rotatedFilePath);
-                times = 1;
-                rotatePolicy.onOpenFile(new File(path));
-                times = 1;
-                rotatePolicy.getSettings();
-                times = 1;
-
-                rotatePolicy.onWrite(anyString, Charset.forName(utf8));
-                times = 2;
-            }
-        };
+            inOrder.verify(rotatePolicy).needsRotate(message, Charset.forName(utf8));
+            inOrder.verify(rotatePolicy).decideRotatedFilePath();
+            inOrder.verify(rotatePolicy).onWrite(anyString(), eq(Charset.forName(utf8)));
+            inOrder.verify(rotatePolicy).rotate(rotatedFilePath);
+            inOrder.verify(rotatePolicy).onOpenFile(new File(path));
+            inOrder.verify(rotatePolicy).getSettings();
+            inOrder.verify(rotatePolicy, times(2)).onWrite(anyString(), eq(Charset.forName(utf8)));
+            
+            verifyNoMoreInteractions(rotatePolicy);
+        }
     }
 
     /** 


### PR DESCRIPTION
`DateRotatePolicyTest` の `testLastModifiedReturnsZero` で `File` のモック化を止めている点について補足。

mockito は、 `File` をモック化することができない（mockito 自体が内部で `File` に依存しているため）。

- [java - Can the mockito3 mockConstruction make stub on 'new File' - Stack Overflow](https://stackoverflow.com/questions/68097251/can-the-mockito3-mockconstruction-make-stub-on-new-file)
- [Can mock construction of 'new File()' with Mockito.mockConstruction · Issue #2342 · mockito/mockito](https://github.com/mockito/mockito/issues/2342)

しかし、このテストでやりたいのは `lastModified` が `0` を返すようにしたいだけなので、そもそもモックを使わなくても `setLastModified` で `0` を設定すれば済む話なので、モックを使わない形に置き換えた。